### PR TITLE
Adds support for Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-lattice-keyring",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Keyring for connecting to the Lattice1 hardware wallet",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Unlike Chromium browsers, Firefox extensions do not live in a `window` environment.
We therefore cannot use the `window` API to open the Lattice connector web page.
This commit adds a logical branch to check on the URL of the opened tab if there
is no access to `window.open`. This check happens on a timer and if a new URL
parameter (`loginCache`) appears, it will attempt to decode that data and form
a set of credentials from it.
Note that the extension must be build with the correct host permission in its
manifest file: we need `https://wallet.gridplus.io/*` as a permission.

Closes #17