### PR TITLE
Removes credentials from storage data

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,6 @@ class LatticeKeyring extends EventEmitter {
   deserialize (opts = {}) {
     if (opts.hdPath)
       this.hdPath = opts.hdPath;
-    if (opts.creds)
-      this.creds = opts.creds;
     if (opts.accounts)
       this.accounts = opts.accounts;
     if (opts.accountIndices)
@@ -52,7 +50,6 @@ class LatticeKeyring extends EventEmitter {
 
   serialize() {
     return Promise.resolve({
-      creds: this.creds,
       accounts: this.accounts,
       accountIndices: this.accountIndices,
       accountOpts: this.accountOpts,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-lattice-keyring",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Keyring for connecting to the Lattice1 hardware wallet",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This forces the user to connect to the same Lattice if MetaMask
gets locked, preventing a user from not being able to connect to
a different device.
Closes #21