### PR TITLE
Removes unnecessary latency by only requiring unlock if it is needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-lattice-keyring",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Keyring for connecting to the Lattice1 hardware wallet",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We were forcing a reconnection to the lattice on every signing request,
which is unnecessary once we have established a connection to the SDK.
Also removes `console.*` calls, as MetaMask no longer offers access
to `console` for submodules unless they are whitelisted on LavaMoat.