### PR TITLE
Forces SDK connection before unlocking extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,12 +164,16 @@ class LatticeKeyring extends EventEmitter {
   getAccounts() {
     return new Promise((resolve, reject) => {
       const accounts = this.accounts ? this.accounts.slice() : [].slice();
-      // If we have already tried to connect, we don't need to do it again --
+      // Exit without connecting?
+      // * If we have no credentials, just return the accounts. It shouldn't be
+      // possible to have addresses without credentials, i.e. it should be an
+      // empty array.
+      // * If we have already tried to connect, we don't need to do it again --
       // just return the accounts. Note that this proceeds regardless of the
       // connection result. If the user's device is offline then the extension
       // will still unlock but the device won't be reachable until it tries to
       // connect again.
-      if (this.triedConnection) {
+      if (!this._hasCreds() || this.triedConnection) {
         return resolve(accounts);
       }
       // Since this is called when the extension unlocks, we should make sure

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ const keyringType = 'Lattice Hardware';
 const HARDENED_OFFSET = 0x80000000;
 const PER_PAGE = 5;
 const CLOSE_CODE = -1000;
-const STANDARD_HD_PATH = `m/44'/60'/0'/0/x`
+const STANDARD_HD_PATH = `m/44'/60'/0'/0/x`;
+const SDK_TIMEOUT = 120000;
+const CONNECT_TIMEOUT = 20000;
 
 class LatticeKeyring extends EventEmitter {
   constructor (opts={}) {
@@ -51,6 +53,7 @@ class LatticeKeyring extends EventEmitter {
   }
 
   serialize() {
+    this.triedConnection = false;
     return Promise.resolve({
       creds: this.creds,
       accounts: this.accounts,
@@ -65,8 +68,10 @@ class LatticeKeyring extends EventEmitter {
     })
   }
 
+  // Deterimine if we have a connection to the Lattice and an existing wallet UID
+  // against which to make requests.
   isUnlocked () {
-    return this._hasCreds() && this._hasSession()
+    return !!this._getCurrentWalletUID()
   }
 
   // Initialize a session with the Lattice1 device using the GridPlus SDK
@@ -82,6 +87,10 @@ class LatticeKeyring extends EventEmitter {
           'You can now add multiple Lattice and SafeCard accounts at the same time! ' +
           'Your accounts have been cleared. Please press Continue to add them back in.'
         ));
+      }
+
+      if (this.isUnlocked()) {
+        return resolve('Unlocked');
       }
 
       this._getCreds()
@@ -151,19 +160,35 @@ class LatticeKeyring extends EventEmitter {
     })
   }
 
-  // Return the local store of addresses
+  // Return the local store of addresses. This gets called when the extension unlocks.
   getAccounts() {
     return new Promise((resolve, reject) => {
+      const accounts = this.accounts ? this.accounts.slice() : [].slice();
+      // If we have already tried to connect, we don't need to do it again --
+      // just return the accounts. Note that this proceeds regardless of the
+      // connection result. If the user's device is offline then the extension
+      // will still unlock but the device won't be reachable until it tries to
+      // connect again.
+      if (this.triedConnection) {
+        return resolve(accounts);
+      }
+      // Since this is called when the extension unlocks, we should make sure
+      // we have a connection with the user's Lattice. If no connection is found
+      // this will attempt to create one. The error will not be handled in this
+      // function because the user could have their Lattice unplugged and may
+      // want to use a different account on MetaMask.
       this._ensureCurrentWalletUID()
       .then(() => {
-        return resolve(this.accounts ? this.accounts.slice() : [].slice());
+        this.triedConnection = true;
+        return resolve(accounts);
       })
       .catch((err) => {
         // Rather than throw an error here, we should still unlock the
         // extension and return whatever accounts we currently have.
         // If we threw an error, it would lock people out of the extension
         // if they could not talk to their Lattice.
-        return resolve(this.accounts ? this.accounts.slice() : [].slice());
+        this.triedConnection = true;
+        return resolve(accounts);
       })
     })
   }
@@ -300,8 +325,8 @@ class LatticeKeyring extends EventEmitter {
             signerPath: this._getHDPathIndices(addressParentPath, addressIdx),
           }
         }
-        if (!this._hasSession())
-          return reject(new Error('No SDK session started. Cannot sign transaction.'));
+        if (!this.isUnlocked())
+          return reject(new Error('No connection to Lattice. Could not send request.'));
         this.sdkSession.sign(req, (err, res) => {
           if (err)
             return reject(new Error(err));
@@ -367,7 +392,10 @@ class LatticeKeyring extends EventEmitter {
   // Note that this is the BIP39 path index, not the index in the address cache.
   _findSignerIdx(address) {
     return new Promise((resolve, reject) => {
-      this.getAccounts()
+      this._ensureCurrentWalletUID()
+      .then(() => {
+        return this.getAccounts()
+      })
       .then((addrs) => {
         // Find the signer in our current set of accounts
         // If we can't find it, return an error
@@ -577,7 +605,12 @@ class LatticeKeyring extends EventEmitter {
   // This will handle SafeCard insertion/removal events.
   _connect() {
     return new Promise((resolve, reject) => {
+      // Attempt to connect with a Lattice using a shorter timeout. If
+      // the device is unplugged it will time out and we don't need to wait
+      // 2 minutes for that to happen.
+      this.sdkSession.timeout = CONNECT_TIMEOUT;
       this.sdkSession.connect(this.creds.deviceID, (err) => {
+        this.sdkSession.timeout = SDK_TIMEOUT;
         if (err)
           return reject(err);
         // Save the current wallet UID
@@ -597,7 +630,7 @@ class LatticeKeyring extends EventEmitter {
 
   _initSession() {
     return new Promise((resolve, reject) => {
-      if (this._hasSession()) {
+      if (this.isUnlocked()) {
         return resolve();
       }
       try {
@@ -608,7 +641,7 @@ class LatticeKeyring extends EventEmitter {
           name: this.appName,
           baseUrl: url,
           crypto,
-          timeout: 120000,
+          timeout: SDK_TIMEOUT,
           privKey: this._genSessionKey(),
           network: this.network
         }
@@ -622,8 +655,8 @@ class LatticeKeyring extends EventEmitter {
 
   _fetchAddresses(n=1, i=0, recursedAddrs=[]) {
     return new Promise((resolve, reject) => {
-      if (!this._hasSession())
-        return reject('No SDK session started. Cannot fetch addresses.')
+      if (!this.isUnlocked())
+        return reject('No connection to Lattice. Cannot fetch addresses.')
 
       this.__fetchAddresses(n, i, (err, addrs) => {
         if (err)
@@ -666,8 +699,8 @@ class LatticeKeyring extends EventEmitter {
 
   _signTxData(txData) {
     return new Promise((resolve, reject) => {
-      if (!this._hasSession())
-        return reject(new Error('No SDK session started. Cannot sign transaction.'));
+      if (!this.isUnlocked())
+        return reject(new Error('No connection to Lattice. Cannot sign transaction.'));
       this.sdkSession.sign({ currency: 'ETH', data: txData }, (err, res) => {
         if (err)
           return reject(err);
@@ -716,10 +749,6 @@ class LatticeKeyring extends EventEmitter {
 
   _hasCreds() {
     return this.creds.deviceID !== null && this.creds.password !== null && this.appName;
-  }
-
-  _hasSession() {
-    return this.sdkSession && this.walletUID;
   }
 
   _genSessionKey() {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "@ethereumjs/tx": "^3.1.1",
     "bignumber.js": "^9.0.1",
     "ethereumjs-util": "^7.0.10",
-    "gridplus-sdk": "^0.9.5"
+    "gridplus-sdk": "^0.9.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-lattice-keyring",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Keyring for connecting to the Lattice1 hardware wallet",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In 0.4.7 we forced an SDK connection to be established before sending
a signing request and, once one was established, skipped that
connection attempt for future requests. This means the first signing
request after opening the extension is still quite slow, but subsequent
ones are much faster.
Since many use cases only require one transaciton at a time, this
seems like a subpar UX. This commit front loads that SDK connection
to `getAccounts`, which is called when the extension unlocks and
searches for Lattice accounts. This means that unlocking the extension
will now take ~5 seconds, but all transaction requests should be
very quick.