### PR TITLE
Retry and rehydrate functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,12 +388,8 @@ class LatticeKeyring extends EventEmitter {
           if (address.toLowerCase() === addr.toLowerCase())
             accountIdx = i;
         })
-        if (accountIdx === null)
+        if (accountIdx === null) {
           return reject('Signer not present');
-        // Make sure the account is associated with the current wallet
-        if (this.accountOpts[accountIdx].walletUID !== this._getCurrentWalletUID()) {
-          return reject(new Error('Account on a different wallet. ' +
-                                  'Please switch to the correct wallet on your Lattice.'));
         }
         return resolve(accountIdx);
       })

--- a/index.js
+++ b/index.js
@@ -79,6 +79,12 @@ class LatticeKeyring extends EventEmitter {
   }
 
   // Initialize a session with the Lattice1 device using the GridPlus SDK
+  // NOTE: `bypassOnStateData=true` allows us to rehydrate a new SDK session without
+  // reconnecting to the target Lattice. This is only currently used for signing 
+  // because it eliminates the need for 2 connection requests and shaves off ~4-6sec.
+  // We avoid passing `bypassOnStateData=true` for other calls on `unlock` to avoid
+  // possible edge cases related to this new functionality (it's probably fine - just
+  // being cautious). In the future we may remove `bypassOnStateData` entirely.
   unlock(bypassOnStateData=false) {
     return new Promise((resolve, reject) => {
       // Force compatability. `this.accountOpts` were added after other
@@ -386,9 +392,6 @@ class LatticeKeyring extends EventEmitter {
     return new Promise((resolve, reject) => {
       // Unlock and get the wallet UID. We will bypass the reconnection
       // step if we are able to rehydrate an SDK session with state data.
-      // This bypass is useful for signing requests since it cuts out 1-2 
-      // additional requests, but should not genrally be used as it makes
-      // error handling more difficult.
       this.unlock(true)
       .then(() => {
         return this._ensureCurrentWalletUID();

--- a/index.js
+++ b/index.js
@@ -628,18 +628,25 @@ class LatticeKeyring extends EventEmitter {
         return resolve();
       }
       try {
-        // Stup an SDK client
         let url = 'https://signing.gridpl.us';
         if (this.creds.endpoint)
           url = this.creds.endpoint
-        const setupData = {
-          name: this.appName,
-          baseUrl: url,
-          crypto,
-          timeout: SDK_TIMEOUT,
-          privKey: this._genSessionKey(),
-          network: this.network,
-          stateData: this.sdkState,
+        let setupData;
+        if (this.sdkState) {
+          // If we have state data we can fully rehydrate the session.
+          setupData = {
+            stateData: this.sdkState
+          }
+        } else {
+          // If we have no state data, we need to create a session.
+          // Its state will be saved once the connection is established.
+          setupData = {
+            name: this.appName,
+            baseUrl: url,
+            timeout: SDK_TIMEOUT,
+            privKey: this._genSessionKey(),
+            network: this.network,
+          }
         }
         this.sdkSession = new SDK.Client(setupData);
         // Return a boolean indicating whether we provided state data.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-lattice-keyring",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "Keyring for connecting to the Lattice1 hardware wallet",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,6 @@
     "@ethereumjs/tx": "^3.1.1",
     "bignumber.js": "^9.0.1",
     "ethereumjs-util": "^7.0.10",
-    "gridplus-sdk": "^0.9.7"
+    "gridplus-sdk": "^0.10.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "@ethereumjs/tx": "^3.1.1",
     "bignumber.js": "^9.0.1",
     "ethereumjs-util": "^7.0.10",
-    "gridplus-sdk": "^0.10.5"
+    "gridplus-sdk": "^1.0.0"
   }
 }


### PR DESCRIPTION
This update allows the keyring to stash state data from the SDK (new in SDK `v0.10.5`) and use that to rehydrate a session without needing to reconnect to the target Lattice. Currently, this is only used with signing requests to avoid introducing unnecessary complexity in other places. Users benefit from this approach with signing requests, as it removes two unnecessary asynchronous calls (`connect`, then `getWallets`).

The above state caching approach means we no longer have to front-load any connections, so that functionality has been removed from `getAccounts`. This was a slightly problematic approach since it put a loading screen in front of the extension whenever it unlocked. If the user's Lattice was unreachable, it would need to wait 20 seconds to timeout, which wasn't great. State caching is a much better approach.

Furthermore, this update caches the state data (including current wallet UID) after every request, since these calls are synchronous and instantaneous.