### PR TITLE
Breaks out pathway and adds decoder data to request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-lattice-keyring",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Keyring for connecting to the Lattice1 hardware wallet",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "@ethereumjs/tx": "3.3.0",
     "bn.js": "^5.2.0",
     "ethereumjs-util": "^7.0.10",
-    "gridplus-sdk": "^1.1.6",
+    "gridplus-sdk": "^1.2.0",
     "rlp": "^3.0.0",
     "secp256k1": "4.0.2"
   }


### PR DESCRIPTION
We now look for the ABI definition on Etherscan and then 4byte if
Etherscan fails. We do this ahead of the request so that we can pack
the ABI definition into the transaction request. This leads to just-in-
time ABI decoding on newer versions of firmware.
Also breaks out the legacy ETH signing pathway into a single helper.