### PR TITLE
Fixes issue with `txData` reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ class LatticeKeyring extends EventEmitter {
     const signerPath = this._getHDPathIndices(hdPath, addressIdx);
     // Lattice firmware v0.11.0 implemented EIP1559 and EIP2930
     // We should throw an error if we cannot support this.
-    if (fwVersion.major === 0 && fwVersion.minor <= 11 && txData.type) {
+    if (fwVersion.major === 0 && fwVersion.minor <= 11) {
       throw new Error('Please update Lattice firmware.');
     }
     // Build the signing request

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eth-lattice-keyring",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eth-lattice-keyring",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/tx": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-lattice-keyring",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Keyring for connecting to the Lattice1 hardware wallet",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I believe this issue is from [this PR](https://github.com/GridPlus/eth-lattice-keyring/pull/37/files). It looks like it was referring to an object that was removed. 

I think we are supposed to check if the transaction is a type that we can't handle (anything other than `0`) so I changed the check to refer to `tx._type` 