### PR TITLE
chore: enable pkg-pr-new

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Build project
         run: npm run build
 
-      # - name: Release a nightly build
-      #   if: env.INTERNAL_EVENT == 'true'
-      #   run: npx pkg-pr-new publish
+      - name: Release a nightly build
+        if: env.INTERNAL_EVENT == 'true'
+        run: npx pkg-pr-new publish


### PR DESCRIPTION
## Summary

Enable `pkg-pr-new` tool to get a temp package build on every PR submitted for testing purposes.